### PR TITLE
Auto merge dependabot PRs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,14 @@
+name: dependabot-auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.mytoken }}


### PR DESCRIPTION
Better to auto merge updates and fix potential regressions than keep using vulnerable dependencies because nobody has the time to review the PRs.